### PR TITLE
Error resolving plugin 'de.undercouch.download'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-    id "de.undercouch.download" version "4.0.4"
+    id "de.undercouch.download"
 }
 
 group 'io.gitjournal.git_bindings'


### PR DESCRIPTION
Fix https://github.com/GitJournal/git_bindings/issues/1

```
Plugin request for plugin already on the classpath must not include a version
```